### PR TITLE
Update indexing of StackedArray and rm whitespace.

### DIFF
--- a/src/GrowableArrays.jl
+++ b/src/GrowableArrays.jl
@@ -36,7 +36,7 @@ module GrowableArrays
   Base.getindex(G::GrowableArray, i::Int) = G.data[i] # expand a linear index out
   Base.getindex(G::GrowableArray, i::Int, I::Int...) = G.data[i][I...]
   function Base.setindex!(G::GrowableArray, elem,i::Int) ##TODO: Add type checking on elem
-      cidx = LinearIndices(size(G))
+    cidx = LinearIndices(size(G))
     G.data[cidx[i]] = elem
   end
   function Base.setindex!(G::GrowableArray, elem,i::Int,I::Int...)

--- a/src/GrowableArrays.jl
+++ b/src/GrowableArrays.jl
@@ -53,7 +53,7 @@ module GrowableArrays
   StackedArray(vec::AbstractVector) = StackedArray(vec, (length(vec), size(vec[1])...)) # TODO: ensure all elements are the same size
   StackedArray(vec::A, dims::NTuple{N}) where {A<:AbstractVector, N} = StackedArray{eltype(eltype(A)),N,A}(vec, dims)
   Base.size(S::StackedArray) = S.dims
-  Base.getindex(S::StackedArray, i::Int) = S.data[ind2sub(size(S), i)...] # expand a linear index out
+  Base.getindex(S::StackedArray, i::Int) = S.data[LinearIndices(size(S))[i]] # expand a linear index out 
   Base.getindex(S::StackedArray, i::Int, I::Int...) = S.data[i][I...]
   Base.push!(G::GrowableArray,Sarr::StackedArray)  = push!(G.data,Sarr.data)
 


### PR DESCRIPTION
Updates `Base.getindex(S::StackedArray, i::Int)` to use `LinearIndices()` and removed whitespace from `Base.setindex!(G::GrowableArray, elem,i::Int)` because it was making my eye twitch.